### PR TITLE
Fix realtime canvas sync stability

### DIFF
--- a/apps/web/app/room/[roomId]/page.tsx
+++ b/apps/web/app/room/[roomId]/page.tsx
@@ -53,6 +53,7 @@ export default function RoomPage({
   const syncTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const membershipInFlightRef = useRef(false);
   const wsAuthRetryRef = useRef(false);
+  const lastCanvasSyncTimeRef = useRef(0);
 
   const [isWaiting, setIsWaiting] = useState(false);
   const [isHost, setIsHost] = useState(false);
@@ -106,7 +107,10 @@ export default function RoomPage({
     const ws = WSClient.getInstance();
     ws.send("room:join", { roomId });
     ws.send("chat:history", { roomId });
-    ws.send("canvas:sync", { roomId });
+    ws.send("canvas:sync", {
+      roomId,
+      fromTime: lastCanvasSyncTimeRef.current || undefined,
+    });
   }, [roomId]);
 
   const connectSocket = useCallback(
@@ -122,7 +126,7 @@ export default function RoomPage({
       setStatus("connecting");
       ws.connect(roomId, nextToken, {
         name: user?.username || user?.email,
-        avatarUrl: user?.avatarUrl
+        avatarUrl: user?.avatarUrl,
       });
     },
     [roomId, setStatus, user?.username, user?.email, user?.avatarUrl],
@@ -252,7 +256,9 @@ export default function RoomPage({
       const state = payload?.status;
       if (!targetId || typeof targetId !== "string") return;
       if (state === "online") {
-        const name = payload.name || (targetId === user?.id
+        const name =
+          payload.name ||
+          (targetId === user?.id
             ? user?.username || "You"
             : `User ${targetId.slice(0, 6)}`);
         setOnline(targetId, name, payload.avatarUrl);
@@ -309,7 +315,13 @@ export default function RoomPage({
       if (rawMessage) setCanvasError(rawMessage);
     });
 
-    const offCanvasLoad = ws.on("canvas:load", () => {
+    const offCanvasLoad = ws.on("canvas:load", (payload) => {
+      if (typeof payload?.snapshotCutoffMs === "number") {
+        lastCanvasSyncTimeRef.current = Math.max(
+          lastCanvasSyncTimeRef.current,
+          payload.snapshotCutoffMs,
+        );
+      }
       setCanvasError(null);
       stopSyncing();
     });
@@ -399,7 +411,10 @@ export default function RoomPage({
     setCanvasError(null);
     startSyncing();
     const ws = WSClient.getInstance();
-    ws.send("canvas:sync", { roomId });
+    ws.send("canvas:sync", {
+      roomId,
+      fromTime: lastCanvasSyncTimeRef.current || undefined,
+    });
   };
 
   const shareRoom = async () => {
@@ -447,9 +462,9 @@ export default function RoomPage({
   const [showCanvas, setShowCanvas] = useState(true);
   const [showChat, setShowChat] = useState(true);
   const [showMedia, setShowMedia] = useState(true);
-  const [insightTab, setInsightTab] = useState<"chat" | "transcript" | "ai" | "tasks">(
-    "chat",
-  );
+  const [insightTab, setInsightTab] = useState<
+    "chat" | "transcript" | "ai" | "tasks"
+  >("chat");
 
   useEffect(() => {
     const nextCanvas = loadBool(PANEL_KEYS.canvas, true);
@@ -696,7 +711,11 @@ export default function RoomPage({
                     title={p.name}
                   >
                     {p.avatarUrl && p.avatarUrl.trim() !== "" ? (
-                      <img src={p.avatarUrl} alt={p.name} className="w-full h-full object-cover" />
+                      <img
+                        src={p.avatarUrl}
+                        alt={p.name}
+                        className="w-full h-full object-cover"
+                      />
                     ) : (
                       p.initials
                     )}

--- a/apps/web/src/components/workspace/CanvasPane.tsx
+++ b/apps/web/src/components/workspace/CanvasPane.tsx
@@ -81,6 +81,7 @@ export const CanvasPane = () => {
   const wheelFrameRef = useRef<number | null>(null);
 
   const objects = useCanvasStore((s) => s.objects);
+  const objectsRef = useRef(objects);
   const objectsVersion = useCanvasStore((s) => s.version);
   const applyUpdate = useCanvasStore((s) => s.applyUpdate);
   const replaceObjects = useCanvasStore((s) => s.replaceObjects);
@@ -111,6 +112,7 @@ export const CanvasPane = () => {
   const eraseVisitedRef = useRef<Set<string>>(new Set());
   const eraseLastPointRef = useRef<{ x: number; y: number } | null>(null);
   const selectionBoxRef = useRef<SelectionBox | null>(null);
+  const remoteTranslateBaseRef = useRef<Map<string, any>>(new Map());
 
   const [activeTool, setActiveTool] = useState<CanvasTool>("draw");
   const [strokeColor, setStrokeColor] = useState("#0d5bd7");
@@ -136,8 +138,12 @@ export const CanvasPane = () => {
     useCanvasView();
 
   const upsertObject = useCallback(
-    (objectId: string, updates: Record<string, any>) => {
-      applyUpdate({ objectId, updates, timestamp: Date.now() });
+    (
+      objectId: string,
+      updates: Record<string, any>,
+      timestamp = Date.now(),
+    ) => {
+      applyUpdate({ objectId, updates, timestamp });
     },
     [applyUpdate],
   );
@@ -211,6 +217,10 @@ export const CanvasPane = () => {
     [objects, objectsVersion],
   );
 
+  useEffect(() => {
+    objectsRef.current = objects;
+  }, [objects]);
+
   const getActiveRoomId = () => roomId ?? WSClient.getInstance().getRoomId();
 
   const setSelectedObject = (objectId: string | null) => {
@@ -243,7 +253,10 @@ export const CanvasPane = () => {
   };
 
   const getEventPointerPosition = (
-    e: PointerEvent | ReactPointerEvent<HTMLCanvasElement> | ReactMouseEvent<HTMLCanvasElement>,
+    e:
+      | PointerEvent
+      | ReactPointerEvent<HTMLCanvasElement>
+      | ReactMouseEvent<HTMLCanvasElement>,
     canvas: HTMLCanvasElement,
   ) => {
     const rect = canvas.getBoundingClientRect();
@@ -967,6 +980,10 @@ export const CanvasPane = () => {
     return next;
   };
 
+  const isPointObject = (obj: any) =>
+    ["stroke", "arrow", "line"].includes(obj?.type) &&
+    Array.isArray(obj?.points);
+
   const getResizeHandles = (obj: any) => {
     const bounds = getObjectBounds(obj);
     if (!bounds)
@@ -1278,24 +1295,56 @@ export const CanvasPane = () => {
       if (!payload?.objectId) return;
 
       // Prevent incoming server/peer updates from overriding objects currently in active local interaction
-      if (isDrawing.current && draftRef.current?.objectId === payload.objectId) {
+      if (
+        isDrawing.current &&
+        draftRef.current?.objectId === payload.objectId
+      ) {
         return;
       }
       if (dragRef.current && dragRef.current.objectId === payload.objectId) {
         return;
       }
-      if (groupDragRef.current && groupDragRef.current.snapshots.some((s) => s.id === payload.objectId)) {
+      if (
+        groupDragRef.current &&
+        groupDragRef.current.snapshots.some((s) => s.id === payload.objectId)
+      ) {
         return;
       }
 
       const rawData = payload?.data;
       const rawProps = rawData?.props ?? rawData ?? {};
+      const payloadTimestamp =
+        typeof payload?.timestamp?.time === "number"
+          ? payload.timestamp.time
+          : Date.now();
+      const translate = rawProps?._translate;
+      if (
+        translate &&
+        typeof translate.dx === "number" &&
+        typeof translate.dy === "number"
+      ) {
+        const existing = objectsRef.current.get(payload.objectId);
+        if (!existing) return;
+        let base = remoteTranslateBaseRef.current.get(payload.objectId);
+        if (!base) {
+          base = cloneHistoryObject(existing);
+          remoteTranslateBaseRef.current.set(payload.objectId, base);
+        }
+        upsertObject(
+          payload.objectId,
+          buildMovedObject(base, translate.dx, translate.dy),
+          payloadTimestamp,
+        );
+        return;
+      }
+
+      remoteTranslateBaseRef.current.delete(payload.objectId);
       const normalized = {
         id: payload.objectId,
         ...rawProps,
         type: rawData?.type ?? rawProps?.type,
       };
-      upsertObject(payload.objectId, normalized);
+      upsertObject(payload.objectId, normalized, payloadTimestamp);
     });
 
     const offLoad = ws.on("canvas:load", (payload) => {
@@ -1303,6 +1352,7 @@ export const CanvasPane = () => {
       const updates = hasSnapshot ? payload.updates : [];
 
       if (hasSnapshot) {
+        remoteTranslateBaseRef.current.clear();
         const nextObjects = new Map<string, any>();
         updates.forEach((entry: any) => {
           if (!entry?.objectId) return;
@@ -1331,7 +1381,13 @@ export const CanvasPane = () => {
           ...rawProps,
           type: rawProps?.type,
         };
-        upsertObject(event.objectId, normalized);
+        upsertObject(
+          event.objectId,
+          normalized,
+          typeof event?.time === "bigint"
+            ? Number(event.time)
+            : Number(event?.time || Date.now()),
+        );
       });
     });
 
@@ -1549,7 +1605,11 @@ export const CanvasPane = () => {
   // High-performance animation loop for fluid drawing
   useEffect(() => {
     const loop = () => {
-      if (isDrawing.current && activeStrokeRef.current && needsRedrawRef.current) {
+      if (
+        isDrawing.current &&
+        activeStrokeRef.current &&
+        needsRedrawRef.current
+      ) {
         drawAllRef.current?.();
         needsRedrawRef.current = false;
       }
@@ -1662,7 +1722,6 @@ export const CanvasPane = () => {
         });
       }
     });
-
   }, [activeFillColor, strokeColor, brushSize]);
 
   useEffect(() => {
@@ -2124,12 +2183,23 @@ export const CanvasPane = () => {
             const before = cloneHistoryObject(objects.get(id));
             const latest = objects.get(id);
             if (latest) {
-              sendCanvasEvent(
-                id,
-                "UPDATE_OBJECT",
-                latest.type || "shape",
-                latest,
-              );
+              if (isGroupMove && isPointObject(latest)) {
+                sendCanvasEvent(id, "UPDATE_OBJECT", latest.type || "stroke", {
+                  id,
+                  type: latest.type,
+                  _translate: {
+                    dx: x - gd.pointerStartX,
+                    dy: y - gd.pointerStartY,
+                  },
+                });
+              } else {
+                sendCanvasEvent(
+                  id,
+                  "UPDATE_OBJECT",
+                  latest.type || "shape",
+                  latest,
+                );
+              }
               recordHistory({
                 objectId: id,
                 before,
@@ -2170,13 +2240,28 @@ export const CanvasPane = () => {
       if (now - (drag.lastEmitAt ?? 0) >= CANVAS_EMIT_INTERVAL_MS) {
         const before = cloneHistoryObject(objects.get(drag.objectId));
         dragRef.current = { ...drag, lastEmitAt: now };
-        upsertObject(drag.objectId, nextObject);
-        sendCanvasEvent(
-          drag.objectId,
-          "UPDATE_OBJECT",
-          nextObject.type || "shape",
-          nextObject,
-        );
+        if (drag.mode === "move" && isPointObject(nextObject)) {
+          sendCanvasEvent(
+            drag.objectId,
+            "UPDATE_OBJECT",
+            nextObject.type || "stroke",
+            {
+              id: drag.objectId,
+              type: nextObject.type || "stroke",
+              _translate: {
+                dx: x - drag.pointerStartX,
+                dy: y - drag.pointerStartY,
+              },
+            },
+          );
+        } else {
+          sendCanvasEvent(
+            drag.objectId,
+            "UPDATE_OBJECT",
+            nextObject.type || "shape",
+            nextObject,
+          );
+        }
         recordHistory({
           objectId: drag.objectId,
           before,
@@ -2196,9 +2281,10 @@ export const CanvasPane = () => {
       if (!canvas) return;
 
       const nativeEvent = e.nativeEvent;
-      const coalescedEvents = typeof nativeEvent.getCoalescedEvents === "function"
-        ? nativeEvent.getCoalescedEvents()
-        : [nativeEvent];
+      const coalescedEvents =
+        typeof nativeEvent.getCoalescedEvents === "function"
+          ? nativeEvent.getCoalescedEvents()
+          : [nativeEvent];
 
       const active = activeStrokeRef.current;
       if (!active) return;
@@ -2224,13 +2310,18 @@ export const CanvasPane = () => {
         needsRedrawRef.current = true;
 
         if (now - (draft.lastEmitAt ?? 0) >= CANVAS_EMIT_INTERVAL_MS) {
+          const MAX_WIRE_POINTS = 300;
+          const wirePoints =
+            active.points.length > MAX_WIRE_POINTS
+              ? active.points.slice(-MAX_WIRE_POINTS)
+              : active.points;
           const props = {
             id: draft.objectId,
             type: "stroke",
             color: strokeColor,
             width: brushSize,
             strokeStyle,
-            points: [...active.points],
+            points: [...wirePoints],
           };
           draftRef.current = { ...draft, lastEmitAt: now };
           sendCanvasEvent(draft.objectId, "UPDATE_OBJECT", "stroke", props);
@@ -2614,7 +2705,11 @@ export const CanvasPane = () => {
                   }}
                   title={tool.label}
                 >
-                  {Icon ? <Icon className="h-4 w-4 stroke-[1.8]" /> : tool.symbol}
+                  {Icon ? (
+                    <Icon className="h-4 w-4 stroke-[1.8]" />
+                  ) : (
+                    tool.symbol
+                  )}
                 </button>
               );
             })}
@@ -2650,7 +2745,10 @@ export const CanvasPane = () => {
                   </button>
                 ))}
                 {/* Custom Color Selector Label */}
-                <label className="h-5 w-5 rounded-full border border-slate-200 bg-white shadow-sm flex items-center justify-center cursor-pointer transition hover:scale-110 text-[10px] text-slate-400 font-bold hover:bg-slate-50" title="Custom color">
+                <label
+                  className="h-5 w-5 rounded-full border border-slate-200 bg-white shadow-sm flex items-center justify-center cursor-pointer transition hover:scale-110 text-[10px] text-slate-400 font-bold hover:bg-slate-50"
+                  title="Custom color"
+                >
                   +
                   <input
                     type="color"
@@ -2674,7 +2772,8 @@ export const CanvasPane = () => {
                   onClick={() => setFillEnabled(false)}
                   className="h-5 w-5 rounded-full border border-slate-200 relative transition duration-150 hover:scale-110 bg-white overflow-hidden"
                   style={{
-                    background: "linear-gradient(135deg, transparent 43%, #ef4444 43%, #ef4444 57%, transparent 57%)",
+                    background:
+                      "linear-gradient(135deg, transparent 43%, #ef4444 43%, #ef4444 57%, transparent 57%)",
                   }}
                   title="Transparent (None)"
                 >
@@ -2700,13 +2799,17 @@ export const CanvasPane = () => {
                     style={{ backgroundColor: color }}
                     title={color}
                   >
-                    {fillEnabled && fillColor.toLowerCase() === color.toLowerCase() && (
-                      <span className="absolute inset-0 m-auto h-1.5 w-1.5 rounded-full bg-slate-800 shadow-sm" />
-                    )}
+                    {fillEnabled &&
+                      fillColor.toLowerCase() === color.toLowerCase() && (
+                        <span className="absolute inset-0 m-auto h-1.5 w-1.5 rounded-full bg-slate-800 shadow-sm" />
+                      )}
                   </button>
                 ))}
                 {/* Custom Fill Color Label */}
-                <label className="h-5 w-5 rounded-full border border-slate-200 bg-white shadow-sm flex items-center justify-center cursor-pointer transition hover:scale-110 text-[10px] text-slate-400 font-bold hover:bg-slate-50" title="Custom fill">
+                <label
+                  className="h-5 w-5 rounded-full border border-slate-200 bg-white shadow-sm flex items-center justify-center cursor-pointer transition hover:scale-110 text-[10px] text-slate-400 font-bold hover:bg-slate-50"
+                  title="Custom fill"
+                >
                   +
                   <input
                     type="color"

--- a/apps/ws-backend/src/consumers/canvas.consumer.ts
+++ b/apps/ws-backend/src/consumers/canvas.consumer.ts
@@ -115,6 +115,7 @@ export async function startCanvasConsumer() {
           return {
             type: "undo",
             version,
+            timestamp: logicalTimestamp,
             result: undone,
           };
         }
@@ -134,6 +135,7 @@ export async function startCanvasConsumer() {
           return {
             type: "redo",
             version,
+            timestamp: logicalTimestamp,
             result: redone,
           };
         }
@@ -144,6 +146,25 @@ export async function startCanvasConsumer() {
         if (event.type !== "canvas.draw") return null;
 
         const { objectId, action, data } = event.payload;
+        const props =
+          data?.props && typeof data.props === "object" ? data.props : data;
+        if (
+          action === "UPDATE_OBJECT" &&
+          props?._translate &&
+          typeof props._translate.dx === "number" &&
+          typeof props._translate.dy === "number"
+        ) {
+          return {
+            type: "object",
+            version,
+            timestamp: logicalTimestamp,
+            objectId,
+            action,
+            data,
+            transient: true,
+          };
+        }
+
         const existing = await tx.canvasObject.findUnique({
           where: { id: objectId },
         });
@@ -164,17 +185,29 @@ export async function startCanvasConsumer() {
           (typeof data?.type === "string" ? data.type : "shape");
 
         // 🔥 3. REDO INVALIDATION
-        await tx.canvasActionHistory.updateMany({
+        const redoCandidate = await tx.canvasActionHistory.findFirst({
           where: {
             roomId: event.roomId,
             userId: event.userId,
             isUndone: true,
             isRedoInvalidated: false,
           },
-          data: {
-            isRedoInvalidated: true,
-          },
+          select: { id: true },
         });
+
+        if (redoCandidate) {
+          await tx.canvasActionHistory.updateMany({
+            where: {
+              roomId: event.roomId,
+              userId: event.userId,
+              isUndone: true,
+              isRedoInvalidated: false,
+            },
+            data: {
+              isRedoInvalidated: true,
+            },
+          });
+        }
 
         // ---- APPLY ACTION ----
 
@@ -221,6 +254,7 @@ export async function startCanvasConsumer() {
         return {
           type: "object",
           version,
+          timestamp: logicalTimestamp,
           objectId,
           action,
           data,
@@ -244,17 +278,23 @@ export async function startCanvasConsumer() {
         }
 
         const outgoing = {
-          type: "canvas:undo",
+          type: "canvas:object",
           payload: {
             objectId: result.result.objectId,
             action: mapHistoryActionToCanvasAction(result.result.actionType),
+            data: {
+              type: result.result.resolvedProps?.type,
+              props: result.result.resolvedProps,
+            },
+            timestamp: result.timestamp,
+            userId: event.userId,
           },
         };
 
         roomManager.broadCast(event.roomId, outgoing);
 
         await safePublish({
-          type: "canvas:undo",
+          type: "canvas:object",
           roomId: event.roomId,
           payload: outgoing.payload,
         });
@@ -278,17 +318,23 @@ export async function startCanvasConsumer() {
         }
 
         const outgoing = {
-          type: "canvas:redo",
+          type: "canvas:object",
           payload: {
             objectId: result.result.objectId,
             action: mapHistoryActionToCanvasAction(result.result.actionType),
+            data: {
+              type: result.result.resolvedProps?.type,
+              props: result.result.resolvedProps,
+            },
+            timestamp: result.timestamp,
+            userId: event.userId,
           },
         };
 
         roomManager.broadCast(event.roomId, outgoing);
 
         await safePublish({
-          type: "canvas:redo",
+          type: "canvas:object",
           roomId: event.roomId,
           payload: outgoing.payload,
         });
@@ -306,9 +352,11 @@ export async function startCanvasConsumer() {
       // 🎨 OBJECT BROADCAST
       // ======================
       if (result.type === "object") {
-        const currentCount = updateRoomEventCount(event.roomId);
+        const currentCount = result.transient
+          ? 0
+          : updateRoomEventCount(event.roomId);
 
-        if (currentCount >= SNAPSHOT_EVERY_EVENTS) {
+        if (!result.transient && currentCount >= SNAPSHOT_EVERY_EVENTS) {
           triggerSnapshot(event.roomId, result.version);
           roomEventCountSinceSnapshot.set(event.roomId, 0);
         }
@@ -324,6 +372,7 @@ export async function startCanvasConsumer() {
             objectId: result.objectId,
             action: result.action,
             data: result.data,
+            timestamp: result.timestamp,
             userId: event.userId,
           },
         };

--- a/apps/ws-backend/src/manager/roomManager.ts
+++ b/apps/ws-backend/src/manager/roomManager.ts
@@ -6,47 +6,6 @@ export class RoomManager {
   private roomSockets: Map<string, Set<AuthenticatedSocket>> = new Map();
   private socketRooms: Map<string, Set<string>> = new Map();
   private roomUsers: Map<string, Map<string, Set<string>>> = new Map();
-  private batchBuffer: Map<string, any[]> = new Map();
-  private batchTimer: NodeJS.Timeout | null = null;
-
-  private flushBatches() {
-    this.batchTimer = null;
-    const currentBatches = this.batchBuffer;
-    this.batchBuffer = new Map();
-
-    for (const [roomId, events] of currentBatches.entries()) {
-      const sockets = this.roomSockets.get(roomId);
-      if (!sockets || events.length === 0) continue;
-
-      const message = JSON.stringify(events);
-      const dead: AuthenticatedSocket[] = [];
-
-      for (const socket of sockets) {
-        if (socket.readyState !== socket.OPEN) {
-          dead.push(socket);
-          continue;
-        }
-        try {
-          socket.send(message);
-        } catch (error) {
-          logger.error(
-            {
-              roomId,
-              socketId: socket.id,
-              userId: socket.userId,
-              error,
-            },
-            "Broadcast send failed",
-          );
-          dead.push(socket);
-        }
-      }
-
-      for (const socket of dead) {
-        this.removeSocket(socket);
-      }
-    }
-  }
 
   joinRoom(roomId: string, socket: AuthenticatedSocket) {
     let sockets = this.roomSockets.get(roomId);
@@ -193,13 +152,16 @@ export class RoomManager {
     const sockets = this.roomSockets.get(roomId);
     if (!sockets) return [];
 
-    const userMap = new Map<string, { id: string; name?: string; avatarUrl?: string | null }>();
+    const userMap = new Map<
+      string,
+      { id: string; name?: string; avatarUrl?: string | null }
+    >();
     for (const s of sockets) {
       if (s.userId && !userMap.has(s.userId)) {
         userMap.set(s.userId, {
           id: s.userId,
           name: s.name,
-          avatarUrl: s.avatarUrl
+          avatarUrl: s.avatarUrl,
         });
       }
     }

--- a/apps/ws-backend/src/router/eventRouter.ts
+++ b/apps/ws-backend/src/router/eventRouter.ts
@@ -91,7 +91,8 @@ export class EventRouter {
         case "canvas:sync":
           void handleCanvasLoad(socket, {
             roomId: event.payload?.roomId,
-            fromTime: event.payload?.lastKnownTimestamp,
+            fromTime:
+              event.payload?.fromTime ?? event.payload?.lastKnownTimestamp,
           }).catch((error) => this.handleAsyncError(socket, error));
           break;
 

--- a/apps/ws-backend/src/services/canvas.history.service.ts
+++ b/apps/ws-backend/src/services/canvas.history.service.ts
@@ -267,7 +267,7 @@ export async function handleUndo(
     },
   });
 
-  return last;
+  return { ...last, resolvedProps: inverseProps };
 }
 
 /**
@@ -372,5 +372,5 @@ export async function handleRedo(
     },
   });
 
-  return action;
+  return { ...action, resolvedProps: redoProps };
 }

--- a/apps/ws-backend/src/services/canvas.service.ts
+++ b/apps/ws-backend/src/services/canvas.service.ts
@@ -33,6 +33,17 @@ export class CanvasService {
     if (!action) return "Action is required";
 
     const shape = getShapeProps(data);
+    if (
+      action === "UPDATE_OBJECT" &&
+      shape?._translate &&
+      typeof shape._translate.dx === "number" &&
+      typeof shape._translate.dy === "number" &&
+      Number.isFinite(shape._translate.dx) &&
+      Number.isFinite(shape._translate.dy)
+    ) {
+      return null;
+    }
+
     const result = CanvasObjectSchema.safeParse(shape);
 
     if (!result.success) {

--- a/apps/ws-backend/src/services/canvasRead.service.ts
+++ b/apps/ws-backend/src/services/canvasRead.service.ts
@@ -1,6 +1,11 @@
 import { prisma } from "@repo/db";
 import { materializeCRDT, mergeCRDT, type CRDTObject } from "../crdt/merge";
 import { isRecord } from "../utils/record.util";
+import { decompressSnapshotData } from "../snapshot/compress";
+
+const MAX_DELTA_EVENTS = Number(
+  process.env.CANVAS_LOAD_MAX_DELTA_EVENTS || 2000,
+);
 
 function readPatch(after: unknown): Record<string, any> | null {
   if (!isRecord(after)) return null;
@@ -18,7 +23,14 @@ function readSnapshotState(snapshot: any) {
   const state = new Map<string, CRDTObject>();
   if (!snapshot) return { state, valid: true };
 
-  const objects = snapshot?.data?.objects;
+  let data: any;
+  try {
+    data = decompressSnapshotData(snapshot.data);
+  } catch {
+    return { state, valid: false };
+  }
+
+  const objects = data?.objects;
   if (!Array.isArray(objects)) return { state, valid: false };
 
   for (const obj of objects) {
@@ -32,6 +44,53 @@ function readSnapshotState(snapshot: any) {
   return { state, valid: true };
 }
 
+function serializeHistoryEvent(event: any) {
+  return {
+    ...event,
+    time: event.time ? Number(event.time) : null,
+    version: event.version ? event.version.toString() : null,
+    undoneAtVersion: event.undoneAtVersion
+      ? event.undoneAtVersion.toString()
+      : null,
+  };
+}
+
+async function buildCurrentCanvasStatePayload(roomId: string) {
+  const objects = await prisma.canvasObject.findMany({
+    where: { roomId },
+    orderBy: [{ time: "asc" }, { actorId: "asc" }],
+    select: {
+      id: true,
+      crdt: true,
+      time: true,
+    },
+  });
+
+  let snapshotCutoffMs = 0;
+  const updates = objects
+    .map((obj) => {
+      if (obj.time && Number(obj.time) > snapshotCutoffMs) {
+        snapshotCutoffMs = Number(obj.time);
+      }
+
+      const data = materialize(obj.crdt as CRDTObject);
+      if (!data) return null;
+
+      return {
+        objectId: obj.id,
+        data,
+      };
+    })
+    .filter(Boolean);
+
+  return {
+    snapshotCutoffMs,
+    updates,
+    replayedEvents: 0,
+    deltaTruncated: true,
+  };
+}
+
 export async function buildCanvasLoadPayload(
   roomId: string,
   fromTime?: number,
@@ -40,17 +99,30 @@ export async function buildCanvasLoadPayload(
     const events = await prisma.canvasActionHistory.findMany({
       where: {
         roomId,
+        isUndone: false,
+        isRedoInvalidated: false,
         time: {
           gt: BigInt(fromTime),
         },
       },
       orderBy: [{ time: "asc" }, { actorId: "asc" }],
+      take: MAX_DELTA_EVENTS,
     });
+
+    if (events.length === MAX_DELTA_EVENTS) {
+      return buildCurrentCanvasStatePayload(roomId);
+    }
+
+    const snapshotCutoffMs = events.reduce((max, event) => {
+      if (!event.time) return max;
+      return Math.max(max, Number(event.time));
+    }, fromTime);
 
     return {
       fromTime,
+      snapshotCutoffMs,
       replayedEvents: events.length,
-      events,
+      events: events.map(serializeHistoryEvent),
     };
   }
 
@@ -74,16 +146,26 @@ export async function buildCanvasLoadPayload(
   const events = await prisma.canvasActionHistory.findMany({
     where: {
       roomId,
+      isUndone: false,
+      isRedoInvalidated: false,
       time: {
         gt: BigInt(snapshotCutoffMs),
       },
     },
     orderBy: [{ time: "asc" }, { actorId: "asc" }],
+    take: MAX_DELTA_EVENTS,
   });
+
+  if (events.length === MAX_DELTA_EVENTS) {
+    return buildCurrentCanvasStatePayload(roomId);
+  }
+
+  let latestEventTimeMs = snapshotCutoffMs;
 
   for (const event of events) {
     if (!event.objectId) continue;
     if (!event.time || !event.actorId) continue;
+    latestEventTimeMs = Math.max(latestEventTimeMs, Number(event.time));
 
     const patch = readPatch(event.after);
     if (!patch) continue;
@@ -113,7 +195,7 @@ export async function buildCanvasLoadPayload(
     .filter(Boolean);
 
   return {
-    snapshotCutoffMs,
+    snapshotCutoffMs: latestEventTimeMs,
     updates,
     replayedEvents: events.length,
   };

--- a/apps/ws-backend/src/socketManager.ts
+++ b/apps/ws-backend/src/socketManager.ts
@@ -22,6 +22,7 @@ type RateEntry = {
 
 const RATE_LIMIT_PER_SEC = Number(process.env.WS_RATE_LIMIT_PER_SEC || 300);
 const RATE_WINDOW_MS = 1000;
+const MAX_MESSAGE_BYTES = Number(process.env.WS_MAX_MESSAGE_BYTES || 256_000);
 // BUG-1: Auth timeout — close the socket if the handshake doesn't arrive in time
 const AUTH_TIMEOUT_MS = 10_000;
 const WRITE_EVENTS = new Set([
@@ -46,7 +47,10 @@ export class SocketManager {
     // Setup heartbeat to detect broken connections that didn't close properly
     const heartbeat = setInterval(() => {
       if (ws.isAlive === false) {
-        logger.warn({ socketId: ws.id, userId: ws.userId }, "Ghost socket detected — terminating");
+        logger.warn(
+          { socketId: ws.id, userId: ws.userId },
+          "Ghost socket detected — terminating",
+        );
         return ws.terminate();
       }
       ws.isAlive = false;
@@ -170,8 +174,8 @@ export class SocketManager {
   }
 
   private async handleMessage(socket: AuthenticatedSocket, raw: string) {
-    if (raw.length > 10_000) {
-      socket.close();
+    if (raw.length > MAX_MESSAGE_BYTES) {
+      sendSocketCodedError(socket, "MSG_TOO_LARGE", "Message too large");
       return;
     }
     try {
@@ -251,7 +255,7 @@ export class SocketManager {
     // BUG-5 FIX: Remove the socket from all rooms BEFORE broadcasting so the
     // disconnecting user does not receive its own "offline" event.
     const offlineRoomIds = roomManager.removeSocket(socket) || [];
-    
+
     // Unregister user socket
     if (socket.userId) {
       const sockets = this.userSockets.get(socket.userId);

--- a/apps/ws-backend/src/utils/canvas.util.ts
+++ b/apps/ws-backend/src/utils/canvas.util.ts
@@ -1,57 +1,30 @@
-import { prisma, SnapshotType } from "@repo/db";
+import { prisma } from "@repo/db";
+import { createBaseSnapshot } from "../snapshot/createBase";
 import { logger } from "../infra/logger";
 
+const SNAPSHOT_RETENTION_WINDOW = 20000n;
+
 export async function triggerSnapshot(roomId: string, version: bigint) {
-  // async, non-blocking
   setImmediate(async () => {
     try {
-      const objects = await prisma.canvasObject.findMany({
-        where: {
-          roomId,
-          version: { lte: version },
-        },
-        select: {
-          id: true,
-          crdt: true,
-          time: true,
-          actorId: true,
-        },
-      });
-
-      const normalizedObjects = objects.map((obj) => ({
-        id: obj.id,
-        crdt: obj.crdt,
-        timestamp:
-          obj.time && obj.actorId
-            ? {
-                time: Number(obj.time),
-                actorId: obj.actorId,
-              }
-            : null,
-      }));
-
-      await prisma.canvasSnapshot.create({
-        data: {
-          roomId,
-          type: SnapshotType.BASE,
-          baseVersion: null,
-          version,
-          data: { objects: normalizedObjects },
-          createdAt: new Date(),
-        },
-      });
-
-      // cleanup old snapshots (keep roughly 1000 seconds of history)
+      await createBaseSnapshot(roomId, version);
       await prisma.canvasSnapshot.deleteMany({
         where: {
           roomId,
-          version: { lt: version - 1000000n },
+          version: {
+            lt:
+              version > SNAPSHOT_RETENTION_WINDOW
+                ? version - SNAPSHOT_RETENTION_WINDOW
+                : 0n,
+          },
         },
       });
-
       logger.info({ roomId, version: version.toString() }, "Snapshot created");
     } catch (err) {
-      logger.error({ err, roomId, version: version.toString() }, "Snapshot error");
+      logger.error(
+        { err, roomId, version: version.toString() },
+        "Snapshot error",
+      );
     }
   });
 }


### PR DESCRIPTION
## Summary
This PR hardens the realtime canvas pipeline against oversized payloads, reconnect drift, stale undo and redo state, and snapshot replay failures.

## What changed

### WebSocket payload safety
- Replaced silent oversized-message socket closes with a coded MSG_TOO_LARGE error.
- Raised the inbound message limit so committed canvas payloads are not treated as network failures.
- Limited in-flight pencil stroke updates to the latest 300 points while preserving the full pointer-up commit.
- Added lightweight translate previews for stroke, line, and arrow movement instead of broadcasting full point arrays during drag.

### Canvas load and reconnect correctness
- Added a safe cap for canvas delta loads.
- Fall back to materialized canvas state when reconnect deltas are too large.
- Filter undone and redo-invalidated history rows out of reconnect deltas.
- Normalize replay rows so BigInt fields are safe to send over JSON.
- Track the last canvas sync timestamp on the client and send fromTime during reconnect or retry sync.

### CRDT and peer ordering
- Server canvas object broadcasts now include the server HLC timestamp.
- The client applies peer updates using the server HLC time instead of local Date.now, preventing local processing order from winning conflicts incorrectly.

### Undo and redo broadcasts
- Undo and redo now return resolved object props.
- Peers receive undo and redo as normal canvas object updates with the restored state.
- Cross-server publish uses the same corrected canvas object payload.

### Snapshot consistency
- The legacy triggerSnapshot path now writes compressed base snapshots through createBaseSnapshot.
- Snapshot reads support compressed payloads via decompressSnapshotData.
- Snapshot retention now matches the scheduler retention window.

### Performance cleanup
- Removed a duplicate drag upsert that caused extra Zustand updates and React renders.
- Gated redo invalidation before updateMany.
- Removed unused RoomManager batch-buffer code.

## Verification
- pnpm --filter ws-backend build
- pnpm --filter web check-types
- pnpm --filter web lint: exits with 0 errors. Existing warnings remain.

Closes #5
Closes #6
Closes #7
Closes #8
Closes #9
Closes #10